### PR TITLE
Fix gfc imports to https://schemas.isotc211.org/schemas/19139

### DIFF
--- a/2005/gfc/gfc.xsd
+++ b/2005/gfc/gfc.xsd
@@ -6,9 +6,9 @@
 		<xs:documentation>Corrected to fit ISO 19110 requirements (Annex E - Organization of the gfc namespace) == 24-06-2011 ====== </xs:documentation>
 	</xs:annotation>
 	<!-- ================================== Imports ================================== -->
-	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmd/citation.xsd"/>
-	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gco/gco.xsd"/>	
-	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/gmx/gmx.xsd"/>	
+	<xs:import namespace="http://www.isotc211.org/2005/gmd" schemaLocation="https://schemas.isotc211.org/schemas/19139/-/gmd/1.0/gmd.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gco" schemaLocation="https://schemas.isotc211.org/schemas/19139/-/gco/1.0/gco.xsd"/>
+	<xs:import namespace="http://www.isotc211.org/2005/gmx" schemaLocation="https://schemas.isotc211.org/schemas/19139/-/gmx/1.0/gmx.xsd"/>
 	<!-- ########################################################################### -->
 	<!-- ########################################################################### -->
 	<!-- ================================== Classes ================================= -->


### PR DESCRIPTION
Updates gfc 0.1 imports to use remote xsds at https://schemas.isotc211.org/schemas/19139 instead of http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/, which doesn't exist anymore.

See also https://github.com/ISO-TC211/www.isotc211.org/pull/35, which is probably preferable.