### PR TITLE
fix: dark mode toggle icon showing both sun and moon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
-    jekyll-theme-isotc211 (1.0.0)
+    jekyll-theme-isotc211 (1.0.1)
       jekyll (~> 4.3)
     jekyll-vite (3.0.4)
       jekyll (>= 3, < 5)
@@ -235,7 +235,7 @@ CHECKSUMS
   jekyll-data (1.1.1) sha256=a9b35201960d076c765f33205753714b719edf8ea2973955d4fab2f87147df7d
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
-  jekyll-theme-isotc211 (1.0.0) sha256=5be65854395b1e36cbd2dcc23dd6cf8a3859ce3524452880a75c2a0a6e59023b
+  jekyll-theme-isotc211 (1.0.1) sha256=ae7cbfe2073a170f313dffadb58b8620ebc4248a91b803c0ffabe1f983b96341
   jekyll-vite (3.0.4) sha256=bb08c6f95e814afeebd73b9299805b85c5daa1964ce85c9e7a0fa77790018785
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
   json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59

--- a/_frontend/css/www.css
+++ b/_frontend/css/www.css
@@ -414,4 +414,9 @@
     margin-top: 0.125rem;
   }
   .dark .repo-card__desc { color: #94a3b8; }
+
+  .icon--sun { display: none; }
+  .icon--moon { display: block; }
+  html.dark .icon--sun { display: block; }
+  html.dark .icon--moon { display: none; }
 }


### PR DESCRIPTION
Fixes the dark/light mode toggle button displaying both sun and moon icons simultaneously. The icon visibility rules are now handled explicitly in CSS instead of relying on Tailwind utility classes that weren't being generated.