### PR TITLE
Use consistent /news/ URL across TC 211 sites

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,8 +39,8 @@ plugins:
 nav:
   - title: About
     url: /about/
-  - title: Blog
-    url: /posts/
+  - title: News
+    url: /news/
 
 footer_links:
   - title: Geodetic Registry

--- a/_pages/posts.adoc
+++ b/_pages/posts.adoc
@@ -1,3 +1,0 @@
----
-layout: posts
----


### PR DESCRIPTION
Update News nav link from /posts to /news/ and remove duplicate posts.adoc page (news.adoc already serves /news/). Part of consistency work across all TC 211 sites.