### PR TITLE
Fix broken title showing '&amp;nbsp' as text

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,33 @@
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% assign page_title = page.title | default: page.name %}
+  <title>{% if page_title %}{{ page_title | escape }} | {% endif %}{{ site.title | strip_html | escape }}</title>
+  <meta name="description"
+    content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}" />
+
+  {% if site.favicon_svg %}
+  <link rel="icon" type="image/svg+xml" href="{{ site.favicon_svg | relative_url }}" />
+  {% endif %}
+  {% if site.favicon_ico %}
+  <link rel="shortcut icon" href="{{ site.favicon_ico | relative_url }}" type="image/vnd.microsoft.icon" />
+  {% endif %}
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Noto+Sans+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <style>
+    html{scroll-behavior:smooth!important}
+    body{font-feature-settings:"kern" 1,"liga" 1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#fff!important;color:#222!important;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,sans-serif!important;opacity:1!important}
+    html.dark body{background-color:#0f172a!important;color:#f1f5f9!important}
+    #nav-header{position:fixed!important;top:0!important;left:0!important;right:0!important;z-index:50!important;height:64px!important}
+    main{padding-top:64px!important}
+  </style>
+
+  {% vite_stylesheet_tag application %}
+
+  {% if jekyll.environment == 'production' and site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
+</head>


### PR DESCRIPTION
## Problem

The browser tab title displays `ISO/TC&amp;nbsp;211` with literal `&amp;nbsp;` text instead of a space.

## Cause

The theme's `head.html` uses `site.title_html` (set to `ISO/TC&amp;nbsp;211`) for the `<title>` tag. After Liquid's `strip_html | escape` filter, the `&amp;nbsp;` becomes `&amp;amp;nbsp;` which renders as literal `&amp;nbsp;` in the browser title bar.

## Fix

Override `_includes/head.html` to use `site.title` (plain text) for the `<title>` element. The `title_html` with `&amp;nbsp;` is still used correctly in the site header and footer where HTML entities are rendered visually.